### PR TITLE
clone_gh_org_repos should respect branch field in packages.json

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -27,3 +27,6 @@
 ^windows$
 data-raw/
 temp-dict/
+^\.env\.example$
+^Dockerfile$
+^entrypoint\.sh$

--- a/R/packages-json.R
+++ b/R/packages-json.R
@@ -213,6 +213,7 @@ clone_gh_org_repos <- function (pkgs_json = NULL, pkgs_dir = NULL) {
 
     out <- pbapply::pblapply (seq_len (nrow (pj)), function (i) {
         url <- paste0 ("https://github.com/", pj$orgrepo [i])
+        branch <- if ("branch" %in% names (pj) && !is.na (pj$branch [i])) pj$branch [i] else NULL
         dir_org <- fs::path_dir (pj$path [i])
         if (!fs::dir_exists (dir_org)) {
             fs::dir_create (dir_org)
@@ -220,12 +221,14 @@ clone_gh_org_repos <- function (pkgs_json = NULL, pkgs_dir = NULL) {
         if (!fs::dir_exists (pj$path [i])) {
             withr::with_dir (
                 dir_org,
-                gert::git_clone (url)
+                gert::git_clone (url, branch = branch)
             )
         } else {
             withr::with_dir (
-                pj$path [i],
-                gert::git_fetch (verbose = FALSE)
+                pj$path [i], {
+                    gert::git_fetch (verbose = FALSE)
+                    if (!is.null (branch)) gert::git_branch_checkout (branch)
+                }
             )
         }
     })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -103,3 +103,33 @@ test_that ("clone gh org repos", {
 
     fs::dir_delete (d)
 })
+
+test_that ("clone gh org repos reads branch field from packages.json", {
+
+    Sys.setenv ("ORGMETRICS_TESTS" = "true")
+    Sys.setenv ("REPOMETRICS_TESTS" = "true")
+
+    d <- fs::path (fs::path_temp (), "orgrepos_branch")
+    expect_false (fs::dir_exists (d))
+    fs::dir_create (d)
+
+    pkgs <- data.frame (
+        path = "ropensci-review-tools/orgmetrics",
+        orgrepo = "ropensci-review-tools/orgmetrics",
+        root = "ropensci-review-tools/orgmetrics",
+        is_r_pkg = TRUE,
+        branch = "main"
+    )
+    pkgs_json <- fs::path (d, "packages.json")
+    jsonlite::write_json (pkgs, pkgs_json, pretty = TRUE)
+
+    clone_gh_org_repos (pkgs_json = pkgs_json)
+
+    repo_path <- fs::path (d, "ropensci-review-tools", "orgmetrics")
+    expect_true (fs::dir_exists (repo_path))
+
+    branch <- withr::with_dir (repo_path, gert::git_branch ())
+    expect_equal (branch, "main")
+
+    fs::dir_delete (d)
+})


### PR DESCRIPTION
In <https://github.com/MRCIEU/mrcieu.r-universe.dev/blob/main/packages.json> we have to take quite a few repos from our forks (for some reason people write non-standard R packages in our field quite alot).

We send fixes from a branch on our fork. However this function isn't respecting the `"branch"` field, e.g.,

```json
  {
    "package": "BWMR",
    "url": "https://github.com/remlapmot/BWMR",
    "branch": "suggestions"
  },
```

This adds that.

And also R CMD check says 3 non-standard files are found, so I added them to .Rbuildignore.